### PR TITLE
[#161] Add badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,59 @@ jobs:
             echo "⚠️ No coverage data available" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Update Coverage Badge
+        if: github.ref == 'refs/heads/main' && success()
+        env:
+          GIST_SECRET: ${{ secrets.GIST_SECRET }}
+          GIST_ID: ${{ secrets.GIST_ID }}
+        run: |
+          if [ ! -f coverage.out ]; then
+            echo "⚠️ No coverage data available, skipping badge update"
+            exit 0
+          fi
+          
+          # Extract coverage percentage
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Coverage: ${COVERAGE}%"
+          
+          # Determine badge color based on coverage
+          COLOR=$(awk -v cov="$COVERAGE" 'BEGIN {
+            if (cov >= 80) print "brightgreen"
+            else if (cov >= 60) print "yellow"
+            else if (cov >= 40) print "orange"
+            else print "red"
+          }')
+          echo "Badge color: $COLOR"
+          
+          # Create JSON for Gist update
+          JSON=$(jq -n \
+            --arg coverage "${COVERAGE}%" \
+            --arg color "${COLOR}" \
+            '{
+              "description": "Code coverage badge for common-library/go",
+              "files": {
+                "coverage.json": {
+                  "content": "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"\($coverage)\", \"color\": \"\($color)\"}"
+                }
+              }
+            }')
+          
+          # Update Gist
+          RESPONSE=$(curl -s -X PATCH \
+            -H "Authorization: token ${GIST_SECRET}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "$JSON" \
+            "https://api.github.com/gists/${GIST_ID}")
+          
+          if echo "$RESPONSE" | jq -e '.id' > /dev/null; then
+            echo "✅ Coverage badge updated successfully"
+            echo "Coverage: ${COVERAGE}% (${COLOR})"
+          else
+            echo "❌ Failed to update coverage badge"
+            echo "$RESPONSE" | jq .
+            exit 1
+          fi
+
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v6
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Common Library for Go
 
+[![CI](https://github.com/common-library/go/workflows/CI/badge.svg)](https://github.com/common-library/go/actions)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/heaven-chp/c7e11ff6ca6c490bd028e4a6d9b79c92/raw/coverage.json)](https://github.com/common-library/go/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/common-library/go)](https://goreportcard.com/report/github.com/common-library/go)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/common-library/go?logo=go)](https://github.com/common-library/go)
+[![Reference](https://pkg.go.dev/badge/github.com/common-library/go.svg)](https://pkg.go.dev/github.com/common-library/go)
+[![License](https://img.shields.io/github/license/common-library/go)](https://github.com/common-library/go/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/common-library/go)](https://github.com/common-library/go/stargazers)
+
 ## Installation
 ```bash
 go get -u github.com/common-library/go


### PR DESCRIPTION
This pull request introduces automated code coverage badge updates and enhances project documentation by adding several status and informational badges to the `README.md`. The most significant changes are the addition of a CI step to update a coverage badge via a GitHub Gist and the inclusion of multiple badges for project visibility.

**CI/CD Improvements:**

* Added a new step to the GitHub Actions workflow (`.github/workflows/ci.yml`) that automatically updates a code coverage badge by calculating coverage from `coverage.out`, determining the badge color, and updating a GitHub Gist with the results. This runs only on successful builds of the `main` branch.

**Documentation Enhancements:**

* Updated `README.md` to include badges for CI status, code coverage, Go Report Card, Go version, documentation reference, license, and GitHub stars, improving project visibility and status at a glance.