### PR TITLE
[#166] Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: false
 
-      - name: Cache Go modules and tools
-        uses: actions/cache@v4
+      - name: Restore Go cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/go/pkg/mod
@@ -166,6 +166,16 @@ jobs:
             echo "$RESPONSE" | jq .
             exit 1
           fi
+
+      - name: Save Go cache
+        if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v'))
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.sum') }}
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
This pull request updates the Go caching strategy in the GitHub Actions CI workflow to use the latest recommended cache actions, improving cache reliability and performance. The changes split the cache restore and save steps, aligning with current best practices.

**CI Workflow Improvements:**

* Replaced the single `actions/cache@v4` step with `actions/cache/restore@v5` for restoring the Go module cache, ensuring compatibility with the latest GitHub Actions caching approach.
* Added a new `actions/cache/save@v5` step to explicitly save the Go module and build caches at the end of the workflow, but only on the `main` branch or version branches, which helps maintain up-to-date caches for important branches.