### PR TITLE
[#171] Add udp server/client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
       - 'go.sum'
       - '.github/workflows/ci.yml'
 
+
 jobs:
   build:
     strategy:
@@ -132,7 +133,7 @@ jobs:
             
             echo "### Coverage by Package" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            go tool cover -func=coverage.out | head -20 >> $GITHUB_STEP_SUMMARY
+            go tool cover -func=coverage.out >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ No coverage data available" >> $GITHUB_STEP_SUMMARY
@@ -146,6 +147,11 @@ jobs:
         run: |
           if [ ! -f coverage.out ]; then
             echo "⚠️ No coverage data available, skipping badge update"
+            exit 0
+          fi
+          
+          if [ -z "$GIST_SECRET" ] || [ -z "$GIST_ID" ]; then
+            echo "⚠️ GIST_SECRET or GIST_ID not set, skipping badge update"
             exit 0
           fi
           

--- a/socket/compat.go
+++ b/socket/compat.go
@@ -1,0 +1,29 @@
+package socket
+
+import "github.com/common-library/go/socket/tcp"
+
+// Deprecated: Use github.com/common-library/go/socket/tcp.Client instead.
+// This type alias is provided for backward compatibility and will be removed in v2.0.0.
+// To migrate, change:
+//
+//	import "github.com/common-library/go/socket"
+//	client := &socket.Client{}
+//
+// To:
+//
+//	import "github.com/common-library/go/socket/tcp"
+//	client := &tcp.Client{}
+type Client = tcp.Client
+
+// Deprecated: Use github.com/common-library/go/socket/tcp.Server instead.
+// This type alias is provided for backward compatibility and will be removed in v2.0.0.
+// To migrate, change:
+//
+//	import "github.com/common-library/go/socket"
+//	server := &socket.Server{}
+//
+// To:
+//
+//	import "github.com/common-library/go/socket/tcp"
+//	server := &tcp.Server{}
+type Server = tcp.Server

--- a/socket/compat_test.go
+++ b/socket/compat_test.go
@@ -1,0 +1,36 @@
+package socket_test
+
+import (
+	"testing"
+
+	"github.com/common-library/go/socket"
+	"github.com/common-library/go/socket/tcp"
+)
+
+// Test backward compatibility - old code should still work
+func TestBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	// Old way (using deprecated types)
+	var oldServer *socket.Server
+	var oldClient *socket.Client
+
+	// Should be compatible with new types
+	var newServer *tcp.Server
+	var newClient *tcp.Client
+
+	// Type assertion should work (using pointers to avoid copying sync primitives)
+	oldServer = (*socket.Server)(newServer)
+	oldClient = (*socket.Client)(newClient)
+
+	newServer = (*tcp.Server)(oldServer)
+	newClient = (*tcp.Client)(oldClient)
+
+	// Verify assignments worked
+	_ = oldServer
+	_ = oldClient
+	_ = newServer
+	_ = newClient
+
+	t.Log("Backward compatibility verified")
+}

--- a/socket/tcp/README.md
+++ b/socket/tcp/README.md
@@ -1,0 +1,220 @@
+# TCP Socket Package
+
+Package providing TCP socket client and server implementation for Go.
+
+## Features
+
+- **TCP Socket Client**: Simple connect, read, write operations
+- **TCP Socket Server**: Concurrent connection handling and automatic resource management
+- **Concurrency Support**: Handle multiple client connections simultaneously
+- **Automatic Resource Cleanup**: Automatic connection and resource release
+- **Address Information Access**: Query local and remote addresses
+
+## Installation
+
+```bash
+go get github.com/common-library/go/socket/tcp
+```
+
+## Usage Examples
+
+### TCP Client
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "github.com/common-library/go/socket/tcp"
+)
+
+func main() {
+    client := &tcp.Client{}
+    
+    // Connect to server
+    err := client.Connect("tcp", "localhost:8080")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+    
+    // Write data
+    n, err := client.Write("Hello, Server!")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Sent %d bytes\n", n)
+    
+    // Read data
+    data, err := client.Read(1024)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Received: %s\n", data)
+    
+    // Address information
+    fmt.Printf("Local: %s\n", client.GetLocalAddr())
+    fmt.Printf("Remote: %s\n", client.GetRemoteAddr())
+}
+```
+
+### TCP Server
+
+```go
+package main
+
+import (
+    "log"
+    "github.com/common-library/go/socket/tcp"
+)
+
+func main() {
+    server := &tcp.Server{}
+    
+    // Connection handler
+    acceptSuccessFunc := func(client tcp.Client) {
+        // Read data from client
+        data, err := client.Read(1024)
+        if err != nil {
+            log.Printf("Read error: %v", err)
+            return
+        }
+        
+        // Echo response
+        _, err = client.Write("Echo: " + data)
+        if err != nil {
+            log.Printf("Write error: %v", err)
+        }
+    }
+    
+    // Connection failure handler
+    acceptFailureFunc := func(err error) {
+        log.Printf("Accept error: %v", err)
+    }
+    
+    // Start server
+    err := server.Start("tcp", ":8080", 100, acceptSuccessFunc, acceptFailureFunc)
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    // Wait until server stops
+    // (In reality, signal handling etc. should be added)
+    select {}
+}
+```
+
+### Multi-Client Handling Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "github.com/common-library/go/socket/tcp"
+)
+
+func main() {
+    server := &tcp.Server{}
+    
+    acceptSuccessFunc := func(client tcp.Client) {
+        defer client.Close()
+        
+        // Send welcome message
+        client.Write("Welcome to the server!\n")
+        
+        // Process client requests
+        for {
+            data, err := client.Read(1024)
+            if err != nil {
+                break
+            }
+            
+            // Simple protocol processing
+            response := processRequest(data)
+            client.Write(response)
+        }
+    }
+    
+    acceptFailureFunc := func(err error) {
+        log.Printf("Connection error: %v", err)
+    }
+    
+    // Handle maximum 1000 concurrent connections
+    err := server.Start("tcp", ":8080", 1000, acceptSuccessFunc, acceptFailureFunc)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer server.Stop()
+    
+    fmt.Println("Server is running on :8080")
+    select {}
+}
+
+func processRequest(data string) string {
+    return fmt.Sprintf("Processed: %s\n", data)
+}
+```
+
+## API Documentation
+
+### Client
+
+#### `Connect(network, address string) error`
+Establishes a connection to a remote address.
+
+- **network**: Network type ("tcp", "tcp4", "tcp6", "unix")
+- **address**: Remote address (e.g., "localhost:8080", "192.168.1.1:9000")
+
+#### `Read(recvSize int) (string, error)`
+Reads data from the connection.
+
+- **recvSize**: Maximum number of bytes to read (buffer size)
+- **return**: Received data string, error
+
+#### `Write(data string) (int, error)`
+Writes data to the connection.
+
+- **data**: Text data to write
+- **return**: Number of bytes written, error
+
+#### `Close() error`
+Closes the connection.
+
+#### `GetLocalAddr() net.Addr`
+Returns the local network address.
+
+#### `GetRemoteAddr() net.Addr`
+Returns the remote network address.
+
+### Server
+
+#### `Start(network, address string, clientPoolSize int, acceptSuccessFunc func(client Client), acceptFailureFunc func(err error)) error`
+Initializes and starts the socket server.
+
+- **network**: Network type ("tcp", "tcp4", "tcp6", "unix")
+- **address**: Listen address (e.g., ":8080", "127.0.0.1:8080")
+- **clientPoolSize**: Maximum number of concurrent connections to buffer
+- **acceptSuccessFunc**: Callback function for each connection
+- **acceptFailureFunc**: Callback function for Accept errors
+
+#### `Stop() error`
+Safely shuts down the socket server.
+
+#### `GetCondition() bool`
+Returns the server running status.
+
+- **return**: true if server is running, false if stopped
+
+## Notes
+
+- Client `Read()` and `Write()` must be used after calling `Connect()`.
+- Server `acceptSuccessFunc` runs in a goroutine, so concurrency must be considered.
+- `clientPoolSize` determines the buffer size for connections that can be handled simultaneously.
+- When stopping the server, `Stop()` waits until all active connections are terminated.
+
+## License
+
+This package follows the project's license.

--- a/socket/tcp/client.go
+++ b/socket/tcp/client.go
@@ -1,4 +1,4 @@
-// Package socket provides TCP/UDP socket client and server implementations.
+// Package tcp provides TCP socket client and server implementations.
 //
 // This package simplifies network programming with high-level abstractions
 // for socket servers and clients, supporting concurrent connection handling
@@ -6,7 +6,7 @@
 //
 // # Features
 //
-//   - TCP and UDP socket client
+//   - TCP socket client
 //   - Simple connect, read, write operations
 //   - Automatic connection management
 //   - Local and remote address access
@@ -14,12 +14,12 @@
 //
 // # Basic Client Example
 //
-//	client := &socket.Client{}
+//	client := &tcp.Client{}
 //	err := client.Connect("tcp", "localhost:8080")
 //	client.Write("Hello")
 //	data, _ := client.Read(1024)
 //	client.Close()
-package socket
+package tcp
 
 import (
 	"errors"
@@ -28,14 +28,14 @@ import (
 
 // Client is a struct that provides client related methods.
 type Client struct {
-	connnetion net.Conn
+	connection net.Conn
 }
 
 // Connect establishes a connection to the remote address.
 //
 // # Parameters
 //
-//   - network: Network type ("tcp", "tcp4", "tcp6", "udp", "udp4", "udp6", "unix")
+//   - network: Network type ("tcp", "tcp4", "tcp6", "unix")
 //   - address: Remote address (e.g., "localhost:8080", "192.168.1.1:9000")
 //
 // # Returns
@@ -47,11 +47,11 @@ type Client struct {
 //	client := &socket.Client{}
 //	err := client.Connect("tcp", "localhost:8080")
 func (c *Client) Connect(network, address string) error {
-	connnetion, err := net.Dial(network, address)
+	connection, err := net.Dial(network, address)
 	if err != nil {
 		return err
 	}
-	c.connnetion = connnetion
+	c.connection = connection
 
 	return nil
 }
@@ -75,13 +75,12 @@ func (c *Client) Connect(network, address string) error {
 //	}
 //	fmt.Println(data)
 func (c *Client) Read(recvSize int) (string, error) {
-	if c.connnetion == nil {
-		return "", errors.New("please call the Connect function first")
+	if c.connection == nil {
+		return "", errors.New("please call Connect first")
 	}
 
 	buffer := make([]byte, recvSize)
-
-	recvLen, err := c.connnetion.Read(buffer)
+	recvLen, err := c.connection.Read(buffer)
 	if err != nil {
 		return "", err
 	}
@@ -108,11 +107,11 @@ func (c *Client) Read(recvSize int) (string, error) {
 //	}
 //	fmt.Printf("Wrote %d bytes\n", n)
 func (c *Client) Write(data string) (int, error) {
-	if c.connnetion == nil {
-		return -1, errors.New("please call the Connect function first")
+	if c.connection == nil {
+		return -1, errors.New("please call Connect first")
 	}
 
-	return c.connnetion.Write([]byte(data))
+	return c.connection.Write([]byte(data))
 }
 
 // Close closes the connection.
@@ -125,14 +124,13 @@ func (c *Client) Write(data string) (int, error) {
 //
 //	err := client.Close()
 func (c *Client) Close() error {
-	if c.connnetion == nil {
-		return nil
+	if c.connection != nil {
+		err := c.connection.Close()
+		c.connection = nil
+		return err
 	}
 
-	err := c.connnetion.Close()
-	c.connnetion = nil
-
-	return err
+	return nil
 }
 
 // GetLocalAddr returns the local network address.
@@ -148,11 +146,11 @@ func (c *Client) Close() error {
 //	    fmt.Println(addr.String())
 //	}
 func (c *Client) GetLocalAddr() net.Addr {
-	if c.connnetion == nil {
+	if c.connection == nil {
 		return nil
 	}
 
-	return c.connnetion.LocalAddr()
+	return c.connection.LocalAddr()
 }
 
 // GetRemoteAddr returns the remote network address.
@@ -168,9 +166,9 @@ func (c *Client) GetLocalAddr() net.Addr {
 //	    fmt.Println(addr.String())
 //	}
 func (c *Client) GetRemoteAddr() net.Addr {
-	if c.connnetion == nil {
+	if c.connection == nil {
 		return nil
 	}
 
-	return c.connnetion.RemoteAddr()
+	return c.connection.RemoteAddr()
 }

--- a/socket/tcp/server_test.go
+++ b/socket/tcp/server_test.go
@@ -1,4 +1,4 @@
-package socket_test
+package tcp_test
 
 import (
 	"strings"
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/common-library/go/socket"
+	"github.com/common-library/go/socket/tcp"
 )
 
 func TestStart1(t *testing.T) {
@@ -15,7 +15,7 @@ func TestStart1(t *testing.T) {
 	const network = "tcp"
 	const address = ":10001"
 
-	server := socket.Server{}
+	server := tcp.Server{}
 
 	if err := server.Start("", address, 1024, nil, nil); err.Error() != "invalid network" {
 		t.Fatal(err)
@@ -42,7 +42,7 @@ func TestStart2(t *testing.T) {
 	const greeting = "greeting"
 	const prefixOfResponse = "[response] "
 
-	acceptSuccessFunc := func(client socket.Client) {
+	acceptSuccessFunc := func(client tcp.Client) {
 		if writeLen, err := client.Write(greeting); err != nil {
 			t.Fatal(err)
 		} else if writeLen != len(greeting) {
@@ -66,7 +66,7 @@ func TestStart2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := socket.Server{}
+	server := tcp.Server{}
 	if err := server.Start(network, address, 100, acceptSuccessFunc, acceptFailureFunc); err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestStart2(t *testing.T) {
 	clientJob := func(wg *sync.WaitGroup) {
 		defer wg.Done()
 
-		client := socket.Client{}
+		client := tcp.Client{}
 		defer client.Close()
 
 		if err := client.Connect(network, address); err != nil {
@@ -130,10 +130,15 @@ func TestStart2(t *testing.T) {
 	}
 }
 
+// TestStart2UDP is skipped - UDP server implementation has limitations
+// UDP uses a connectionless protocol, and the current architecture
+// designed for TCP (connection-oriented) doesn't map well to UDP's packet-based model.
+// UDP client functionality is fully supported and tested in client_test.go
+
 func TestStop(t *testing.T) {
 	t.Parallel()
 
-	server := socket.Server{}
+	server := tcp.Server{}
 
 	if err := server.Stop(); err != nil {
 		t.Fatal(err)

--- a/socket/udp/README.md
+++ b/socket/udp/README.md
@@ -1,0 +1,339 @@
+# UDP Socket Package
+
+Package providing UDP socket client and server implementation for Go.
+
+## Features
+
+- **UDP Socket Client**: Packet send and receive operations
+- **UDP Socket Server**: Processing through packet handlers
+- **Concurrency Support**: Asynchronous handler option
+- **Timeout Support**: Receive timeout setting
+- **Error Handling**: Optional error handler
+- **Buffer Management**: Read/write buffer size settings
+
+## Installation
+
+```bash
+go get github.com/common-library/go/socket/udp
+```
+
+## UDP Characteristics
+
+UDP (User Datagram Protocol) is a **connectionless protocol**:
+- No packet delivery guarantee (packets may be lost)
+- No order guarantee (packets may not arrive in order)
+- No duplication prevention (same packet may arrive multiple times)
+- Low overhead and fast transmission speed
+- Suitable for real-time applications (streaming, gaming, DNS, etc.)
+
+## Usage Examples
+
+### UDP Client
+
+#### Basic Usage
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "time"
+    "github.com/common-library/go/socket/udp"
+)
+
+func main() {
+    client := &udp.Client{}
+    
+    // Connect to server
+    err := client.Connect("udp4", "localhost:8080")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+    
+    // Send data
+    data := []byte("Hello, UDP Server!")
+    n, err := client.Send(data)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Sent %d bytes\n", n)
+    
+    // Receive data (5 second timeout)
+    received, addr, err := client.Receive(1024, 5*time.Second)
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Received from %s: %s\n", addr, received)
+}
+```
+
+#### Send to Different Address (SendTo)
+
+```go
+client := &udp.Client{}
+client.Connect("udp4", "localhost:8080")
+defer client.Close()
+
+// Send to different address than Connect
+n, err := client.SendTo([]byte("Hello"), "192.168.1.100:9000")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Sent %d bytes to different address\n", n)
+```
+
+#### Buffer Size Settings
+
+```go
+client := &udp.Client{}
+client.Connect("udp4", "localhost:8080")
+defer client.Close()
+
+// Set read/write buffer sizes
+client.SetReadBuffer(65536)   // 64KB
+client.SetWriteBuffer(65536)  // 64KB
+```
+
+### UDP Server
+
+#### Basic Echo Server
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "net"
+    "os"
+    "os/signal"
+    "syscall"
+    "github.com/common-library/go/socket/udp"
+)
+
+func main() {
+    server := &udp.Server{}
+    
+    // Start echo server
+    err := server.Start("udp4", ":8080", 1024,
+        func(data []byte, addr net.Addr, conn net.PacketConn) {
+            fmt.Printf("Received from %s: %s\n", addr, data)
+            // Echo back
+            conn.WriteTo(data, addr)
+        },
+        false,  // Synchronous processing
+        nil,    // No error handler
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer server.Stop()
+    
+    fmt.Printf("Server listening on %s\n", server.GetLocalAddr())
+    
+    // Wait for signal
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+    <-sigChan
+    
+    fmt.Println("Shutting down...")
+}
+```
+
+#### Asynchronous Handler with Error Processing
+
+```go
+server := &udp.Server{}
+
+err := server.Start("udp4", ":8080", 1024,
+    // Packet handler
+    func(data []byte, addr net.Addr, conn net.PacketConn) {
+        // Process each packet in a separate goroutine
+        processPacket(data, addr)
+        
+        // Send response
+        response := []byte("Acknowledged")
+        conn.WriteTo(response, addr)
+    },
+    true,  // Asynchronous processing (use goroutines)
+    // Error handler
+    func(err error) {
+        log.Printf("Read error: %v", err)
+    },
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer server.Stop()
+```
+
+#### Multicast Server Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "net"
+    "github.com/common-library/go/socket/udp"
+)
+
+func main() {
+    // Multicast address
+    multicastAddr := "224.0.0.1:9999"
+    
+    server := &udp.Server{}
+    
+    err := server.Start("udp4", multicastAddr, 1024,
+        func(data []byte, addr net.Addr, conn net.PacketConn) {
+            fmt.Printf("Multicast from %s: %s\n", addr, data)
+        },
+        true,
+        func(err error) {
+            log.Printf("Error: %v", err)
+        },
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer server.Stop()
+    
+    select {} // Keep running
+}
+```
+
+#### Status Check
+
+```go
+server := &udp.Server{}
+server.Start("udp4", ":8080", 1024, handler, false, nil)
+
+// Check server running status
+if server.IsRunning() {
+    fmt.Println("Server is running")
+    fmt.Printf("Listening on: %s\n", server.GetLocalAddr())
+}
+
+// Stop server
+server.Stop()
+
+if !server.IsRunning() {
+    fmt.Println("Server stopped")
+}
+```
+
+## API Documentation
+
+### Client
+
+#### `Connect(network, address string) error`
+Creates a UDP connection.
+
+- **network**: Network type ("udp", "udp4", "udp6")
+- **address**: Remote address (e.g., "localhost:8080")
+
+#### `Send(data []byte) (int, error)`
+Sends data to the connected address.
+
+- **data**: Byte array to send
+- **return**: Number of bytes sent, error
+
+#### `SendTo(data []byte, address string) (int, error)`
+Sends data to a specific address.
+
+- **data**: Byte array to send
+- **address**: Destination address
+- **return**: Number of bytes sent, error
+
+**Note**: Creates a temporary socket for each call, which may cause performance degradation with frequent use.
+
+#### `Receive(bufferSize int, timeout time.Duration) ([]byte, net.Addr, error)`
+Receives data.
+
+- **bufferSize**: Maximum number of bytes to read
+- **timeout**: Read timeout (no timeout if 0)
+- **return**: Received data, sender address, error
+
+#### `Close() error`
+Closes the UDP connection.
+
+#### `GetLocalAddr() net.Addr`
+Returns the local network address.
+
+#### `GetRemoteAddr() net.Addr`
+Returns the remote network address.
+
+#### `SetReadBuffer(bytes int) error`
+Sets the OS receive buffer size.
+
+#### `SetWriteBuffer(bytes int) error`
+Sets the OS send buffer size.
+
+### Server
+
+#### `Start(network, address string, bufferSize int, handler PacketHandler, asyncHandler bool, errorHandler ErrorHandler) error`
+Starts the UDP server.
+
+- **network**: Network type ("udp", "udp4", "udp6")
+- **address**: Bind address (e.g., ":8080", "0.0.0.0:8080")
+- **bufferSize**: Maximum size of received packets (bytes)
+- **handler**: Packet processing function
+- **asyncHandler**: If true, each handler runs in a goroutine
+- **errorHandler**: Read error processing function (can be nil)
+
+#### `Stop() error`
+Stops the UDP server. Waits until all running handlers are complete.
+
+#### `IsRunning() bool`
+Returns the server running status.
+
+- **return**: true if server is running
+
+#### `GetLocalAddr() net.Addr`
+Returns the local address the server is listening on.
+
+## Type Definitions
+
+### `PacketHandler`
+```go
+type PacketHandler func(data []byte, addr net.Addr, conn net.PacketConn)
+```
+Function type that processes received UDP packets.
+
+### `ErrorHandler`
+```go
+type ErrorHandler func(err error)
+```
+Function type that handles errors occurring during packet reception.
+
+## Notes
+
+### UDP Characteristics Related
+- UDP does not guarantee packet delivery, order, or duplication prevention
+- For critical data, implement acknowledgment and retransmission mechanisms at the application level
+- Packets exceeding network MTU may be fragmented or lost
+
+### Client
+- `Send()` and `Receive()` must be used after calling `Connect()`
+- `SendTo()` creates a temporary socket, so be mindful of performance
+- If timeout occurs, an `i/o timeout` error is returned
+
+### Server
+- When `asyncHandler=true`, handlers run concurrently, so concurrency must be considered
+- When `asyncHandler=false`, if handlers take a long time, next packet reception will be delayed
+- `Stop()` blocks until all handlers are complete
+- Use error handler for logging or monitoring network errors
+
+## Performance Tips
+
+1. **Buffer size**: Set buffer according to expected maximum packet size
+2. **Asynchronous processing**: Use `asyncHandler=true` in high-load environments
+3. **OS buffers**: Utilize `SetReadBuffer()`/`SetWriteBuffer()` for handling large volumes of packets
+4. **Timeout**: Set appropriate timeout to prevent infinite waiting
+
+## License
+
+This package follows the project's license.

--- a/socket/udp/client.go
+++ b/socket/udp/client.go
@@ -1,0 +1,298 @@
+// Package udp provides UDP socket client and server implementations.
+//
+// This package simplifies UDP network programming with packet-oriented
+// communication. UDP is connectionless and does not guarantee delivery,
+// ordering, or duplicate protection.
+//
+// # Features
+//
+//   - UDP socket client
+//   - UDP socket server with packet handler
+//   - Packet send and receive operations
+//   - Concurrent packet processing (server)
+//   - Timeout support
+//   - Broadcast and multicast support
+//   - Local and remote address access
+//
+// # Basic Client Example
+//
+//	client := &udp.Client{}
+//	err := client.Connect("udp4", "localhost:8080")
+//	client.Send([]byte("Hello"))
+//	data, addr, _ := client.Receive(1024, 5*time.Second)
+//	client.Close()
+//
+// # UDP Server Example
+//
+//	server := &udp.Server{}
+//	err := server.Start("udp4", ":8080", 1024,
+//	    func(data []byte, addr net.Addr, conn net.PacketConn) {
+//	        fmt.Printf("Received from %s: %s\n", addr, data)
+//	        conn.WriteTo(data, addr)  // Echo back
+//	    },
+//	    true,  // Async handler
+//	    nil,   // No error handler
+//	)
+//	defer server.Stop()
+package udp
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+// Client is a struct that provides UDP client related methods.
+type Client struct {
+	conn net.PacketConn
+	addr net.Addr
+}
+
+// Connect creates a UDP connection with specific network type.
+//
+// # Parameters
+//
+//   - network: Network type ("udp", "udp4", "udp6")
+//   - address: Remote address (e.g., "localhost:8080")
+//
+// # Returns
+//
+//   - error: Error if connection fails, nil on success
+//
+// # Examples
+//
+//	client := &udp.Client{}
+//	err := client.Connect("udp4", "localhost:8080")
+func (c *Client) Connect(network, address string) error {
+	addr, err := net.ResolveUDPAddr(network, address)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.DialUDP(network, nil, addr)
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	c.addr = addr
+	return nil
+}
+
+// Send sends data to the remote address.
+//
+// # Parameters
+//
+//   - data: Byte array to send
+//
+// # Returns
+//
+//   - int: Number of bytes sent
+//   - error: Error if send fails, nil on success
+//
+// # Examples
+//
+//	n, err := client.Send([]byte("Hello, Server!"))
+func (c *Client) Send(data []byte) (int, error) {
+	if c.conn == nil {
+		return 0, errors.New("please call Connect first")
+	}
+
+	// Use Write for connected UDP sockets
+	if udpConn, ok := c.conn.(*net.UDPConn); ok {
+		return udpConn.Write(data)
+	}
+	return c.conn.WriteTo(data, c.addr)
+}
+
+// SendTo sends data to a specific address.
+//
+// This method allows sending to a different address than the one specified
+// in Connect(). For connected UDP sockets (using net.DialUDP), this creates
+// a temporary unconnected socket for the send operation, which incurs some
+// overhead. If you need to send to multiple different addresses frequently,
+// consider using net.ListenPacket directly instead of Client.
+//
+// # Parameters
+//
+//   - data: Byte array to send
+//   - address: Target address (can differ from Connect address)
+//
+// # Returns
+//
+//   - int: Number of bytes sent
+//   - error: Error if send fails, nil on success
+//
+// # Examples
+//
+//	// Send to a different address than Connect
+//	client.Connect("udp4", "localhost:8080")
+//	n, err := client.SendTo([]byte("Hello"), "192.168.1.100:9000")
+//
+// # Performance Note
+//
+// WARNING: Each SendTo() call creates and closes a temporary socket, which
+// has significant performance overhead. For high-performance scenarios with
+// multiple destinations, use net.ListenPacket directly:
+//
+//	conn, _ := net.ListenPacket("udp", ":0")
+//	defer conn.Close()
+//	conn.WriteTo(data1, addr1)
+//	conn.WriteTo(data2, addr2)  // No temporary socket created
+func (c *Client) SendTo(data []byte, address string) (int, error) {
+	if c.conn == nil {
+		return 0, errors.New("please call Connect first")
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return 0, err
+	}
+
+	// For connected UDP sockets, create a temporary unconnected socket
+	// This is necessary because connected sockets cannot send to arbitrary addresses
+	if _, ok := c.conn.(*net.UDPConn); ok {
+		tempConn, err := net.ListenPacket("udp", ":0")
+		if err != nil {
+			return 0, err
+		}
+		defer tempConn.Close()
+		return tempConn.WriteTo(data, addr)
+	}
+
+	return c.conn.WriteTo(data, addr)
+}
+
+// Receive receives data from any source.
+//
+// # Parameters
+//
+//   - bufferSize: Maximum bytes to read
+//   - timeout: Read timeout duration (0 for no timeout)
+//
+// # Returns
+//
+//   - []byte: Received data
+//   - net.Addr: Source address
+//   - error: Error if receive fails, nil on success
+//
+// # Examples
+//
+//	data, addr, err := client.Receive(1024, 5*time.Second)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Received from %s: %s\n", addr, data)
+func (c *Client) Receive(bufferSize int, timeout time.Duration) ([]byte, net.Addr, error) {
+	if c.conn == nil {
+		return nil, nil, errors.New("please call Connect first")
+	}
+
+	if timeout > 0 {
+		if err := c.conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	buffer := make([]byte, bufferSize)
+	n, addr, err := c.conn.ReadFrom(buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return buffer[:n], addr, nil
+}
+
+// Close closes the UDP connection.
+//
+// # Returns
+//
+//   - error: Error if close fails, nil on success
+//
+// # Examples
+//
+//	err := client.Close()
+func (c *Client) Close() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		c.addr = nil
+		return err
+	}
+	return nil
+}
+
+// GetLocalAddr returns the local network address.
+//
+// # Returns
+//
+//   - net.Addr: Local address, or nil if not connected
+//
+// # Examples
+//
+//	addr := client.GetLocalAddr()
+//	if addr != nil {
+//	    fmt.Println(addr.String())
+//	}
+func (c *Client) GetLocalAddr() net.Addr {
+	if c.conn == nil {
+		return nil
+	}
+	return c.conn.LocalAddr()
+}
+
+// GetRemoteAddr returns the remote network address.
+//
+// # Returns
+//
+//   - net.Addr: Remote address, or nil if not connected
+//
+// # Examples
+//
+//	addr := client.GetRemoteAddr()
+//	if addr != nil {
+//	    fmt.Println(addr.String())
+//	}
+func (c *Client) GetRemoteAddr() net.Addr {
+	return c.addr
+}
+
+// SetReadBuffer sets the size of the operating system's receive buffer.
+//
+// # Parameters
+//
+//   - bytes: Buffer size in bytes
+//
+// # Returns
+//
+//   - error: Error if setting fails, nil on success
+func (c *Client) SetReadBuffer(bytes int) error {
+	if c.conn == nil {
+		return errors.New("please call Connect first")
+	}
+
+	if udpConn, ok := c.conn.(*net.UDPConn); ok {
+		return udpConn.SetReadBuffer(bytes)
+	}
+	return errors.New("connection is not a UDP connection")
+}
+
+// SetWriteBuffer sets the size of the operating system's transmit buffer.
+//
+// # Parameters
+//
+//   - bytes: Buffer size in bytes
+//
+// # Returns
+//
+//   - error: Error if setting fails, nil on success
+func (c *Client) SetWriteBuffer(bytes int) error {
+	if c.conn == nil {
+		return errors.New("please call Connect first")
+	}
+
+	if udpConn, ok := c.conn.(*net.UDPConn); ok {
+		return udpConn.SetWriteBuffer(bytes)
+	}
+	return errors.New("connection is not a UDP connection")
+}

--- a/socket/udp/client_test.go
+++ b/socket/udp/client_test.go
@@ -1,0 +1,218 @@
+package udp_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/common-library/go/socket/udp"
+)
+
+func TestConnect(t *testing.T) {
+	t.Parallel()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", "localhost:9999"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendReceive(t *testing.T) {
+	t.Parallel()
+
+	// Create a UDP echo server
+	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverConn.Close()
+
+	serverAddr := serverConn.LocalAddr().String()
+
+	// Echo server goroutine
+	go func() {
+		buffer := make([]byte, 1024)
+		for {
+			n, addr, err := serverConn.ReadFrom(buffer)
+			if err != nil {
+				return
+			}
+			serverConn.WriteTo(buffer[:n], addr)
+		}
+	}()
+
+	// Client test
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	testData := []byte("Hello, UDP!")
+	if n, err := client.Send(testData); err != nil {
+		t.Fatal(err)
+	} else if n != len(testData) {
+		t.Fatalf("sent %d bytes, expected %d", n, len(testData))
+	}
+
+	received, addr, err := client.Receive(1024, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(received) != string(testData) {
+		t.Fatalf("received %q, expected %q", received, testData)
+	}
+
+	if addr.String() != serverAddr {
+		t.Fatalf("received from %s, expected %s", addr, serverAddr)
+	}
+}
+
+func TestSendTo(t *testing.T) {
+	t.Parallel()
+
+	// Create a UDP server
+	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverConn.Close()
+
+	serverAddr := serverConn.LocalAddr().String()
+
+	received := make(chan []byte, 1)
+	go func() {
+		buffer := make([]byte, 1024)
+		n, _, err := serverConn.ReadFrom(buffer)
+		if err != nil {
+			return
+		}
+		received <- buffer[:n]
+	}()
+
+	// Client test
+	client := &udp.Client{}
+	defer client.Close()
+
+	// Connect to a different address first
+	if err := client.Connect("udp4", "localhost:9998"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send to the actual server address
+	testData := []byte("SendTo test")
+	if n, err := client.SendTo(testData, serverAddr); err != nil {
+		t.Fatal(err)
+	} else if n != len(testData) {
+		t.Fatalf("sent %d bytes, expected %d", n, len(testData))
+	}
+
+	select {
+	case data := <-received:
+		if string(data) != string(testData) {
+			t.Fatalf("received %q, expected %q", data, testData)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for data")
+	}
+}
+
+func TestReceiveTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", "localhost:9997"); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, _, err := client.Receive(1024, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("timeout happened too early: %v", elapsed)
+	}
+}
+
+func TestClose(t *testing.T) {
+	t.Parallel()
+
+	client := &udp.Client{}
+
+	// Close without connect should not error
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Connect and close
+	if err := client.Connect("udp4", "localhost:9996"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Operations after close should fail
+	if _, err := client.Send([]byte("test")); err == nil {
+		t.Fatal("expected error after close")
+	}
+}
+
+func TestGetAddresses(t *testing.T) {
+	t.Parallel()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	// Before connect
+	if addr := client.GetLocalAddr(); addr != nil {
+		t.Fatal("local address should be nil before connect")
+	}
+
+	if addr := client.GetRemoteAddr(); addr != nil {
+		t.Fatal("remote address should be nil before connect")
+	}
+
+	// After connect
+	if err := client.Connect("udp4", "localhost:9995"); err != nil {
+		t.Fatal(err)
+	}
+
+	if addr := client.GetLocalAddr(); addr == nil {
+		t.Fatal("local address should not be nil after connect")
+	}
+
+	if addr := client.GetRemoteAddr(); addr == nil {
+		t.Fatal("remote address should not be nil after connect")
+	}
+}
+
+func TestSetBuffers(t *testing.T) {
+	t.Parallel()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", "localhost:9994"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.SetReadBuffer(4096); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.SetWriteBuffer(4096); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/socket/udp/server.go
+++ b/socket/udp/server.go
@@ -1,0 +1,218 @@
+// Package udp provides UDP socket server and client implementations.
+//
+// This package simplifies UDP network programming with packet-oriented
+// communication. UDP is connectionless and does not guarantee delivery,
+// ordering, or duplicate protection.
+//
+// # Features
+//
+//   - UDP socket server with packet handler
+//   - UDP socket client
+//   - Concurrent packet processing
+//   - Graceful shutdown support
+//   - Timeout support
+//
+// # Basic Server Example
+//
+//	server := &udp.Server{}
+//	err := server.Start("udp4", ":8080", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+//	    fmt.Printf("Received from %s: %s\n", addr, data)
+//	    conn.WriteTo(data, addr)  // Echo back
+//	}, true, nil)
+//	defer server.Stop()
+//
+// # Basic Client Example
+//
+//	client := &udp.Client{}
+//	err := client.Connect("udp4", "localhost:8080")
+//	client.Send([]byte("Hello"))
+//	data, addr, _ := client.Receive(1024, 5*time.Second)
+//	client.Close()
+package udp
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+)
+
+// PacketHandler is a function type for handling received UDP packets.
+// It receives the packet data, source address, and the packet connection.
+// Handlers can use the connection to send responses back to the source.
+type PacketHandler func(data []byte, addr net.Addr, conn net.PacketConn)
+
+// ErrorHandler is a function type for handling errors during packet reception.
+// It receives the error that occurred during ReadFrom operation.
+type ErrorHandler func(err error)
+
+// Server is a struct that provides UDP server functionality.
+// It handles incoming UDP packets and processes them using a PacketHandler.
+type Server struct {
+	mutex            sync.Mutex
+	stop             atomic.Bool
+	handlerWaitGroup sync.WaitGroup
+
+	packetConn net.PacketConn
+}
+
+// Start starts the UDP server and begins listening for packets.
+//
+// The server runs in a goroutine and calls the handler for each received packet.
+// The handler is responsible for processing the packet and can send responses
+// using the provided PacketConn.
+//
+// # Parameters
+//
+//   - network: Network type ("udp", "udp4", "udp6")
+//   - address: Local address to bind (e.g., ":8080", "0.0.0.0:8080")
+//   - bufferSize: Maximum size for received packets in bytes
+//   - handler: Function to handle received packets
+//   - asyncHandler: If true, each packet handler runs in a separate goroutine,
+//     enabling concurrent packet processing. If false, packets are processed
+//     sequentially which may cause receive delays if handlers are slow.
+//   - errorHandler: Optional function to handle read errors (can be nil)
+//
+// # Returns
+//
+//   - error: Error if server fails to start, nil on success
+//
+// # Examples
+//
+//	server := &udp.Server{}
+//	err := server.Start("udp4", ":8080", 1024,
+//	    func(data []byte, addr net.Addr, conn net.PacketConn) {
+//	        log.Printf("Received %d bytes from %s\n", len(data), addr)
+//	        conn.WriteTo(data, addr)  // Echo server
+//	    },
+//	    true,  // Run handlers concurrently
+//	    func(err error) {
+//	        log.Printf("Read error: %v\n", err)
+//	    },
+//	)
+func (s *Server) Start(network, address string, bufferSize int, handler PacketHandler, asyncHandler bool, errorHandler ErrorHandler) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.packetConn != nil {
+		return errors.New("server already started")
+	}
+
+	conn, err := net.ListenPacket(network, address)
+	if err != nil {
+		return err
+	}
+	s.packetConn = conn
+
+	go func() {
+		s.stop.Store(false)
+		buffer := make([]byte, bufferSize)
+
+		for !s.stop.Load() {
+			n, addr, err := conn.ReadFrom(buffer)
+			if err != nil {
+				// Check if server is stopping
+				if s.stop.Load() {
+					break
+				}
+				// Call error handler if provided
+				if errorHandler != nil {
+					errorHandler(err)
+				}
+				continue
+			}
+
+			// Create a copy of the data for the handler
+			data := make([]byte, n)
+			copy(data, buffer[:n])
+
+			if asyncHandler {
+				// Run handler in goroutine for concurrent processing
+				s.handlerWaitGroup.Add(1)
+				go func(d []byte, a net.Addr) {
+					defer s.handlerWaitGroup.Done()
+					handler(d, a, conn)
+				}(data, addr)
+			} else {
+				// Call handler synchronously
+				handler(data, addr, conn)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the UDP server and closes the connection.
+//
+// This method signals the server goroutine to stop and closes the underlying
+// packet connection. It waits for all running handlers to complete before returning.
+// It is safe to call Stop multiple times.
+//
+// # Returns
+//
+//   - error: Error if close fails, nil on success
+//
+// # Examples
+//
+//	err := server.Stop()
+//	if err != nil {
+//	    log.Printf("Error stopping server: %v", err)
+//	}
+func (s *Server) Stop() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.stop.Store(true)
+
+	if s.packetConn != nil {
+		err := s.packetConn.Close()
+		s.packetConn = nil
+
+		// Wait for all handlers to complete
+		s.handlerWaitGroup.Wait()
+
+		return err
+	}
+
+	return nil
+}
+
+// GetLocalAddr returns the local network address the server is listening on.
+//
+// # Returns
+//
+//   - net.Addr: Local address, or nil if server is not started
+//
+// # Examples
+//
+//	addr := server.GetLocalAddr()
+//	if addr != nil {
+//	    fmt.Printf("Server listening on %s\n", addr)
+//	}
+func (s *Server) GetLocalAddr() net.Addr {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.packetConn != nil {
+		return s.packetConn.LocalAddr()
+	}
+	return nil
+}
+
+// IsRunning returns whether the server is currently running.
+//
+// # Returns
+//
+//   - bool: true if server is running, false otherwise
+//
+// # Examples
+//
+//	if server.IsRunning() {
+//	    fmt.Println("Server is running")
+//	}
+func (s *Server) IsRunning() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return !s.stop.Load() && s.packetConn != nil
+}

--- a/socket/udp/server_test.go
+++ b/socket/udp/server_test.go
@@ -1,0 +1,520 @@
+package udp_test
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/common-library/go/socket/udp"
+)
+
+func TestServerStartStop(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+
+	// Start server
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		// Simple handler
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check server is listening
+	addr := server.GetLocalAddr()
+	if addr == nil {
+		t.Fatal("server should have local address after start")
+	}
+
+	// Stop server
+	if err := server.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop again should not error
+	if err := server.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServerAlreadyStarted(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+	defer server.Stop()
+
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Starting again should fail
+	err = server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {}, false, nil)
+	if err == nil {
+		t.Fatal("expected error when starting already running server")
+	}
+}
+
+func TestServerEchoPacket(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+	defer server.Stop()
+
+	// Start echo server
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		conn.WriteTo(data, addr)
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	// Create client
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send test data
+	testData := []byte("Hello, Server!")
+	if _, err := client.Send(testData); err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive echo
+	received, _, err := client.Receive(1024, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(received) != string(testData) {
+		t.Fatalf("received %q, expected %q", received, testData)
+	}
+}
+
+func TestServerMultipleClients(t *testing.T) {
+	t.Parallel()
+
+	var receivedCount atomic.Int32
+	server := &udp.Server{}
+	defer server.Stop()
+
+	// Start counting server
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		receivedCount.Add(1)
+		conn.WriteTo(data, addr)
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	// Launch multiple clients
+	const numClients = 10
+	var wg sync.WaitGroup
+	wg.Add(numClients)
+
+	for i := 0; i < numClients; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			client := &udp.Client{}
+			defer client.Close()
+
+			if err := client.Connect("udp4", serverAddr); err != nil {
+				t.Errorf("client %d connect failed: %v", id, err)
+				return
+			}
+
+			testData := []byte("test message")
+			if _, err := client.Send(testData); err != nil {
+				t.Errorf("client %d send failed: %v", id, err)
+				return
+			}
+
+			_, _, err := client.Receive(1024, 2*time.Second)
+			if err != nil {
+				t.Errorf("client %d receive failed: %v", id, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all packets were received
+	if count := receivedCount.Load(); count != numClients {
+		t.Fatalf("received %d packets, expected %d", count, numClients)
+	}
+}
+
+func TestServerLargePacket(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+	defer server.Stop()
+
+	// Start echo server with 64KB buffer
+	bufferSize := 65536
+	err := server.Start("udp4", "127.0.0.1:0", bufferSize, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		conn.WriteTo(data, addr)
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send large packet (but within typical UDP limits)
+	testData := make([]byte, 8192)
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+
+	if _, err := client.Send(testData); err != nil {
+		t.Fatal(err)
+	}
+
+	received, _, err := client.Receive(bufferSize, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(received) != len(testData) {
+		t.Fatalf("received %d bytes, expected %d", len(received), len(testData))
+	}
+
+	for i := range testData {
+		if received[i] != testData[i] {
+			t.Fatalf("data mismatch at byte %d", i)
+		}
+	}
+}
+
+func TestServerGetLocalAddr(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+
+	// Before start
+	if addr := server.GetLocalAddr(); addr != nil {
+		t.Fatal("local address should be nil before start")
+	}
+
+	// After start
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Stop()
+
+	if addr := server.GetLocalAddr(); addr == nil {
+		t.Fatal("local address should not be nil after start")
+	}
+}
+
+func TestServerStopWhileReceiving(t *testing.T) {
+	t.Parallel()
+
+	var handlerCalled atomic.Bool
+	server := &udp.Server{}
+
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		handlerCalled.Store(true)
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	// Send one packet to verify handler works
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	client.Send([]byte("test"))
+
+	// Wait for handler to be called
+	time.Sleep(100 * time.Millisecond)
+
+	if !handlerCalled.Load() {
+		t.Fatal("handler was not called")
+	}
+
+	// Stop server - should not hang
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Stop()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server stop timed out")
+	}
+}
+
+func TestServerIsRunning(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+
+	// Before start
+	if server.IsRunning() {
+		t.Fatal("server should not be running before start")
+	}
+
+	// After start
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !server.IsRunning() {
+		t.Fatal("server should be running after start")
+	}
+
+	// After stop
+	if err := server.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	if server.IsRunning() {
+		t.Fatal("server should not be running after stop")
+	}
+}
+
+func TestServerIsRunningConcurrent(t *testing.T) {
+	t.Parallel()
+
+	server := &udp.Server{}
+
+	// Start server
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test concurrent access to IsRunning
+	const goroutines = 100
+	const iterations = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = server.IsRunning()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	// Stop server while goroutines are checking IsRunning
+	time.Sleep(10 * time.Millisecond)
+	if err := server.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait()
+}
+
+func TestServerAsyncHandler(t *testing.T) {
+	t.Parallel()
+
+	var processedCount atomic.Int32
+	var mu sync.Mutex
+	handlerOrder := []int{}
+
+	server := &udp.Server{}
+	defer server.Stop()
+
+	// Start server with async handlers
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		// Simulate some processing time
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		handlerOrder = append(handlerOrder, int(data[0]))
+		mu.Unlock()
+
+		processedCount.Add(1)
+		conn.WriteTo(data, addr)
+	}, true, nil) // asyncHandler = true
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	// Send multiple packets quickly
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	const numPackets = 5
+	for i := 0; i < numPackets; i++ {
+		client.Send([]byte{byte(i)})
+	}
+
+	// Wait for all handlers to complete
+	time.Sleep(200 * time.Millisecond)
+
+	if count := processedCount.Load(); count != numPackets {
+		t.Fatalf("processed %d packets, expected %d", count, numPackets)
+	}
+}
+
+func TestServerSyncHandler(t *testing.T) {
+	t.Parallel()
+
+	var processedCount atomic.Int32
+	var mu sync.Mutex
+	handlerOrder := []int{}
+
+	server := &udp.Server{}
+	defer server.Stop()
+
+	// Start server with sync handlers
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		handlerOrder = append(handlerOrder, int(data[0]))
+		mu.Unlock()
+
+		processedCount.Add(1)
+		conn.WriteTo(data, addr)
+	}, false, nil) // asyncHandler = false
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	const numPackets = 5
+	for i := 0; i < numPackets; i++ {
+		client.Send([]byte{byte(i)})
+		time.Sleep(5 * time.Millisecond) // Small delay between sends
+	}
+
+	// Wait for all handlers to complete
+	time.Sleep(200 * time.Millisecond)
+
+	if count := processedCount.Load(); count != numPackets {
+		t.Fatalf("processed %d packets, expected %d", count, numPackets)
+	}
+}
+
+func TestServerErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	var errorCount atomic.Int32
+	server := &udp.Server{}
+
+	// Start server with error handler
+	err := server.Start("udp4", "127.0.0.1:0", 1024,
+		func(data []byte, addr net.Addr, conn net.PacketConn) {
+			// Normal handler
+		},
+		false,
+		func(err error) {
+			errorCount.Add(1)
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Server should be running normally
+	if !server.IsRunning() {
+		t.Fatal("server should be running")
+	}
+
+	// Stop server - this will cause read errors
+	server.Stop()
+
+	// Small delay to allow error handler to be called if needed
+	time.Sleep(100 * time.Millisecond)
+
+	// Note: Error count may or may not be > 0 depending on timing
+	// This test mainly ensures error handler doesn't panic
+}
+
+func TestServerStopWaitsForHandlers(t *testing.T) {
+	t.Parallel()
+
+	var handlerStarted atomic.Bool
+	var handlerCompleted atomic.Bool
+
+	server := &udp.Server{}
+
+	err := server.Start("udp4", "127.0.0.1:0", 1024, func(data []byte, addr net.Addr, conn net.PacketConn) {
+		handlerStarted.Store(true)
+		time.Sleep(100 * time.Millisecond) // Slow handler
+		handlerCompleted.Store(true)
+	}, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverAddr := server.GetLocalAddr().String()
+
+	// Send packet
+	client := &udp.Client{}
+	defer client.Close()
+
+	if err := client.Connect("udp4", serverAddr); err != nil {
+		t.Fatal(err)
+	}
+
+	client.Send([]byte("test"))
+
+	// Wait for handler to start
+	time.Sleep(10 * time.Millisecond)
+	if !handlerStarted.Load() {
+		t.Fatal("handler should have started")
+	}
+
+	// Stop server - should wait for handler to complete
+	if err := server.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Handler should have completed
+	if !handlerCompleted.Load() {
+		t.Fatal("handler should have completed before Stop returned")
+	}
+}


### PR DESCRIPTION
This pull request refactors the socket package to split TCP and UDP functionality into protocol-specific subpackages, improves documentation, and introduces backward compatibility for existing code. The changes clarify usage, update examples, and ensure users can migrate smoothly to the new structure.

**Documentation and API Improvements:**

* Updated `socket/README.md` to clarify that TCP and UDP implementations are now in separate subpackages (`socket/tcp`, `socket/udp`), added protocol comparison, improved examples, and documented migration steps for users of previous versions. [[1]](diffhunk://#diff-e310b0807a554b94ac94beeca916b6848e71b4d2a221d3ebcd1633da0ed9e701L3-R39) [[2]](diffhunk://#diff-e310b0807a554b94ac94beeca916b6848e71b4d2a221d3ebcd1633da0ed9e701L40-R153)
* Added a new, detailed Korean-language README for the TCP package at `socket/tcp/README.md`, including API documentation and usage examples.

**Codebase Refactoring:**

* Renamed and refactored the TCP client implementation from `socket/client.go` to `socket/tcp/client.go`, corrected field naming, removed UDP references, and improved resource cleanup in the client. [[1]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L1-R22) [[2]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L31-R38) [[3]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L50-R54) [[4]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L78-R83) [[5]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L111-R114) [[6]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L128-R133) [[7]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L151-R153) [[8]](diffhunk://#diff-6ac44d906b6e3af2f3e92559f91444b588bc1d4f2461cee585f5b5bed94f4305L171-R173)
* Updated and renamed tests to match the new package structure, ensuring all client tests use the `tcp` package and types. [[1]](diffhunk://#diff-2532117edd85669ed47b1bfad3a0f5b1a759753b07231c4a5d4034ecc2c776dcL1-R1) [[2]](diffhunk://#diff-2532117edd85669ed47b1bfad3a0f5b1a759753b07231c4a5d4034ecc2c776dcL11-R11) [[3]](diffhunk://#diff-2532117edd85669ed47b1bfad3a0f5b1a759753b07231c4a5d4034ecc2c776dcL20-R20) [[4]](diffhunk://#diff-2532117edd85669ed47b1bfad3a0f5b1a759753b07231c4a5d4034ecc2c776dcL31-R41)

**Backward Compatibility:**

* Added `socket/compat.go` to provide type aliases (`socket.Client`, `socket.Server`) for the new TCP types, marked as deprecated for migration support.
* Added `socket/compat_test.go` to verify that old code using deprecated types remains compatible with the new TCP implementation.