### PR TITLE
[#173] [http] Add convenience function

### DIFF
--- a/database/prometheus/exporter/exporter.go
+++ b/database/prometheus/exporter/exporter.go
@@ -166,7 +166,7 @@ func UnRegisterCollector(collectors ...prometheus.Collector) bool {
 //	// Wait for server to be ready
 //	time.Sleep(100 * time.Millisecond)
 func Start(address, urlPath string, listenAndServeFailureFunc func(error)) error {
-	server.RegisterHandler(urlPath, promhttp.Handler(), net_http.MethodGet)
+	server.RegisterHandler(net_http.MethodGet, urlPath, promhttp.Handler())
 
 	return server.Start(address, listenAndServeFailureFunc)
 }

--- a/event/cloudevents/server.go
+++ b/event/cloudevents/server.go
@@ -83,7 +83,7 @@ func (s *Server) Start(address string, handler func(Event) (*Event, Result), lis
 
 		return err
 	} else {
-		s.server.RegisterPathPrefixHandler("/", eventReceiver)
+		s.server.RegisterPathPrefixHandlerAny("/", eventReceiver)
 
 		return s.server.Start(address, listenAndServeFailureFunc)
 	}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -28,12 +28,12 @@ func TestRequestGET(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/test/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/test/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
 		vars := gorilla_mux.Vars(r)
 		id := vars["id"]
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(fmt.Sprintf(`{"id":"%s","method":"GET"}`, id)))
-	}, net_http.MethodGet)
+	})
 
 	if err := server.Start(":30080", func(err error) { t.Fatalf("Server error: %v", err) }); err != nil {
 		t.Fatal(err)
@@ -62,13 +62,13 @@ func TestRequestPOST(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/users", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodPost, "/users", func(w net_http.ResponseWriter, r *net_http.Request) {
 		if r.Method != net_http.MethodPost {
 			t.Errorf("Expected POST, got %s", r.Method)
 		}
 		w.WriteHeader(net_http.StatusCreated)
 		w.Write([]byte(`{"status":"created"}`))
-	}, net_http.MethodPost)
+	})
 
 	if err := server.Start(":30081", func(err error) { t.Fatalf("Server error: %v", err) }); err != nil {
 		t.Fatal(err)
@@ -98,7 +98,7 @@ func TestRequestWithHeaders(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/headers", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/headers", func(w net_http.ResponseWriter, r *net_http.Request) {
 		contentType := r.Header.Get("Content-Type")
 		apiKey := r.Header.Get("X-API-Key")
 		customHeader := r.Header.Get("X-Custom-Header")
@@ -137,7 +137,7 @@ func TestRequestWithMultipleHeaderValues(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/multi-headers", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/multi-headers", func(w net_http.ResponseWriter, r *net_http.Request) {
 		values := r.Header["X-Multi"]
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(fmt.Sprintf(`{"count":%d,"values":["%s","%s"]}`,
@@ -171,7 +171,7 @@ func TestRequestWithBasicAuth(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/auth", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/auth", func(w net_http.ResponseWriter, r *net_http.Request) {
 		username, password, ok := r.BasicAuth()
 		if !ok {
 			w.WriteHeader(net_http.StatusUnauthorized)
@@ -209,7 +209,7 @@ func TestRequestWithoutBasicAuth(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/no-auth", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/no-auth", func(w net_http.ResponseWriter, r *net_http.Request) {
 		_, _, ok := r.BasicAuth()
 		if ok {
 			t.Error("Should not have basic auth")
@@ -241,12 +241,12 @@ func TestRequestPUT(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/users/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodPut, "/users/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
 		vars := gorilla_mux.Vars(r)
 		id := vars["id"]
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(fmt.Sprintf(`{"id":"%s","method":"PUT"}`, id)))
-	}, net_http.MethodPut)
+	})
 
 	if err := server.Start(":30086", func(err error) { t.Fatalf("Server error: %v", err) }); err != nil {
 		t.Fatal(err)
@@ -272,12 +272,12 @@ func TestRequestDELETE(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/users/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodDelete, "/users/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
 		vars := gorilla_mux.Vars(r)
 		id := vars["id"]
 		w.WriteHeader(net_http.StatusNoContent)
 		w.Write([]byte(fmt.Sprintf(`{"id":"%s","deleted":true}`, id)))
-	}, net_http.MethodDelete)
+	})
 
 	if err := server.Start(":30087", func(err error) { t.Fatalf("Server error: %v", err) }); err != nil {
 		t.Fatal(err)
@@ -301,7 +301,7 @@ func TestRequestResponseHeaders(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/response-headers", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/response-headers", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.Header().Set("X-Custom-Response", "custom-value")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(net_http.StatusOK)
@@ -346,7 +346,7 @@ func TestRequestWithMiddleware(t *testing.T) {
 	}
 
 	server.Use(middleware)
-	server.RegisterHandlerFunc("/test", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/test", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	})

--- a/http/echo/server.go
+++ b/http/echo/server.go
@@ -56,6 +56,79 @@ func (s *Server) RegisterHandler(method string, path string, handler echo.Handle
 	s.getEcho().Add(method, path, handler, middleware...)
 }
 
+// RegisterHandlerAny registers an HTTP handler for all methods (GET, POST, PUT, DELETE, etc.) with optional middleware.
+//
+// Parameters:
+//   - path: URL path pattern
+//   - handler: Echo handler function
+//   - middleware: Optional middleware functions
+//
+// Example:
+//
+//	server.RegisterHandlerAny("/users/:id", getUserHandler)
+func (s *Server) RegisterHandlerAny(path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.getEcho().Any(path, handler, middleware...)
+}
+
+// WrapHandler wraps a standard http.Handler into an Echo handler function.
+//
+// This function allows you to use standard Go http.Handler implementations
+// (such as http.FileServer, third-party handlers, or http.HandlerFunc)
+// within the Echo framework.
+//
+// Parameters:
+//   - handler: Standard http.Handler to wrap
+//
+// Returns:
+//   - echo.HandlerFunc: Echo-compatible handler function
+//
+// Example:
+//
+//	// Wrap http.FileServer
+//	fs := http.FileServer(http.Dir("./static"))
+//	server.RegisterHandler(echo.GET, "/static/*", WrapHandler(fs))
+//
+//	// Wrap http.HandlerFunc
+//	stdHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//	    w.Write([]byte("Hello from standard handler"))
+//	})
+//	server.RegisterHandler(echo.GET, "/std", WrapHandler(stdHandler))
+func WrapHandler(handler http.Handler) echo.HandlerFunc {
+	return echo.WrapHandler(handler)
+}
+
+// WrapHandlerFunc wraps a standard http.HandlerFunc into an Echo handler function.
+//
+// This is a convenience function that wraps http.HandlerFunc (a function type)
+// into an Echo-compatible handler. It's functionally equivalent to WrapHandler
+// but provides better type clarity when working with HandlerFunc types.
+//
+// Parameters:
+//   - handlerFunc: Standard http.HandlerFunc to wrap
+//
+// Returns:
+//   - echo.HandlerFunc: Echo-compatible handler function
+//
+// Example:
+//
+//	// Wrap a HandlerFunc directly
+//	handler := func(w http.ResponseWriter, r *http.Request) {
+//	    w.WriteHeader(http.StatusOK)
+//	    w.Write([]byte("Hello World"))
+//	}
+//	server.RegisterHandler(echo.GET, "/hello", WrapHandlerFunc(handler))
+//
+//	// Or use with http.HandlerFunc type conversion
+//	server.RegisterHandler(echo.POST, "/api", WrapHandlerFunc(
+//	    http.HandlerFunc(myStandardHandler),
+//	))
+func WrapHandlerFunc(handlerFunc http.HandlerFunc) echo.HandlerFunc {
+	return echo.WrapHandler(handlerFunc)
+}
+
 // Use registers global middleware.
 //
 // Parameters:

--- a/http/gin/server.go
+++ b/http/gin/server.go
@@ -72,6 +72,62 @@ func (s *Server) RegisterHandlerAny(relativePath string, handlers ...gin.Handler
 	s.getEngine().Any(relativePath, handlers...)
 }
 
+// WrapHandler wraps a standard http.Handler into a Gin handler function.
+//
+// This function allows you to use standard Go http.Handler implementations
+// (such as http.FileServer, third-party handlers, or http.HandlerFunc)
+// within the Gin framework.
+//
+// Parameters:
+//   - handler: Standard http.Handler to wrap
+//
+// Returns:
+//   - gin.HandlerFunc: Gin-compatible handler function
+//
+// Example:
+//
+//	// Wrap http.FileServer
+//	fs := http.FileServer(http.Dir("./static"))
+//	server.RegisterHandler(http.MethodGet, "/static/*filepath", WrapHandler(fs))
+//
+//	// Wrap http.HandlerFunc
+//	stdHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//	    w.Write([]byte("Hello from standard handler"))
+//	})
+//	server.RegisterHandler(http.MethodGet, "/std", WrapHandler(stdHandler))
+func WrapHandler(handler http.Handler) gin.HandlerFunc {
+	return gin.WrapH(handler)
+}
+
+// WrapHandlerFunc wraps a standard http.HandlerFunc into a Gin handler function.
+//
+// This is a convenience function that wraps http.HandlerFunc (a function type)
+// into a Gin-compatible handler. It uses Gin's WrapF function which is optimized
+// for HandlerFunc types.
+//
+// Parameters:
+//   - handlerFunc: Standard http.HandlerFunc to wrap
+//
+// Returns:
+//   - gin.HandlerFunc: Gin-compatible handler function
+//
+// Example:
+//
+//	// Wrap a HandlerFunc directly
+//	handler := func(w http.ResponseWriter, r *http.Request) {
+//	    w.WriteHeader(http.StatusOK)
+//	    w.Write([]byte("Hello World"))
+//	}
+//	server.RegisterHandler(http.MethodGet, "/hello", WrapHandlerFunc(handler))
+//
+//	// Or use with http.HandlerFunc type conversion
+//	server.RegisterHandler(http.MethodPost, "/api", WrapHandlerFunc(
+//	    http.HandlerFunc(myStandardHandler),
+//	))
+func WrapHandlerFunc(handlerFunc http.HandlerFunc) gin.HandlerFunc {
+	return gin.WrapF(handlerFunc)
+}
+
 // Use registers global middleware.
 //
 // Parameters:

--- a/http/mux/server_test.go
+++ b/http/mux/server_test.go
@@ -23,7 +23,7 @@ func TestRegisterHandler(t *testing.T) {
 		w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	server.RegisterHandler("/test/{id}", handler)
+	server.RegisterHandlerAny("/test/{id}", handler)
 	server.Start(":20080", func(err error) {
 		t.Errorf("Server error: %v", err)
 	})
@@ -56,12 +56,12 @@ func TestRegisterHandlerFunc(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/test/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFunc(net_http.MethodGet, "/test/{id}", func(w net_http.ResponseWriter, r *net_http.Request) {
 		vars := gorilla_mux.Vars(r)
 		id := vars["id"]
 		w.WriteHeader(net_http.StatusOK)
 		fmt.Fprintf(w, `{"id":"%s"}`, id)
-	}, net_http.MethodGet)
+	})
 
 	server.Start(":20081", func(err error) {
 		t.Errorf("Server error: %v", err)
@@ -88,10 +88,17 @@ func TestRegisterHandlerFuncMethods(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/data", func(w net_http.ResponseWriter, r *net_http.Request) {
+	// Register GET handler
+	server.RegisterHandlerFunc(net_http.MethodGet, "/data", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(`{"method":"` + r.Method + `"}`))
-	}, net_http.MethodGet, net_http.MethodPost)
+	})
+
+	// Register POST handler
+	server.RegisterHandlerFunc(net_http.MethodPost, "/data", func(w net_http.ResponseWriter, r *net_http.Request) {
+		w.WriteHeader(net_http.StatusOK)
+		w.Write([]byte(`{"method":"` + r.Method + `"}`))
+	})
 
 	server.Start(":20082", func(err error) {
 		t.Errorf("Server error: %v", err)
@@ -135,7 +142,7 @@ func TestRegisterPathPrefixHandler(t *testing.T) {
 		w.Write([]byte(`{"prefix":"matched"}`))
 	})
 
-	server.RegisterPathPrefixHandler("/api/", handler, net_http.MethodGet)
+	server.RegisterPathPrefixHandler(net_http.MethodGet, "/api/", handler)
 	server.Start(":20083", func(err error) {
 		t.Errorf("Server error: %v", err)
 	})
@@ -167,7 +174,7 @@ func TestRegisterPathPrefixHandlerFunc(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterPathPrefixHandlerFunc("/static/", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterPathPrefixHandlerFuncAny("/static/", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte(`static content`))
 	})
@@ -206,7 +213,7 @@ func TestUseMiddleware(t *testing.T) {
 	}
 
 	server.Use(middleware)
-	server.RegisterHandlerFunc("/test", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFuncAny("/test", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 		w.Write([]byte("ok"))
 	})
@@ -238,7 +245,7 @@ func TestStartStop(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFuncAny("/", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 	})
 
@@ -270,7 +277,7 @@ func TestAlreadyStarted(t *testing.T) {
 
 	server := &mux.Server{}
 
-	server.RegisterHandlerFunc("/", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFuncAny("/", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 	})
 
@@ -337,7 +344,7 @@ func TestIsRunning(t *testing.T) {
 		t.Error("New server should not be running")
 	}
 
-	server.RegisterHandlerFunc("/", func(w net_http.ResponseWriter, r *net_http.Request) {
+	server.RegisterHandlerFuncAny("/", func(w net_http.ResponseWriter, r *net_http.Request) {
 		w.WriteHeader(net_http.StatusOK)
 	})
 


### PR DESCRIPTION
This pull request introduces improvements to HTTP server handler registration and middleware integration for both Echo and Gin frameworks, focusing on simplifying the API and enhancing interoperability with standard Go HTTP handlers. The changes include new utility functions for wrapping standard handlers, expanded documentation, and minor refactoring for clarity and consistency.

### API Enhancements for Handler Registration

* Added `RegisterHandlerAny` to both Echo (`http/echo/server.go`) and Gin (`http/gin/server.go`) servers, allowing registration of a handler for all HTTP methods on a given path. This is documented and demonstrated in both `README.md` files. [[1]](diffhunk://#diff-6cbc86e3225fcd4831d822546917f658b67bc18c0c487e3b444d4ccf5c732525R59-R131) [[2]](diffhunk://#diff-c2cd4d98c0be637a585834ea907177e62082548e5368af2727637af9b68e94e1R75-R130) [[3]](diffhunk://#diff-1ecb319ee37f8e13a3f994d919f9efd34d3a6cd7cad269e5419bc2dbb51d1949L235-R298) [[4]](diffhunk://#diff-0b0eb79e73a3fb6ff8fb51fcfaa26ca0090131139b81f71a177ff107fe21ab06L298-R347)

### Standard Handler Wrapping Utilities

* Introduced `WrapHandler` and `WrapHandlerFunc` utility functions for both Echo and Gin servers to easily wrap standard Go `http.Handler` and `http.HandlerFunc` types into framework-compatible handler functions. Usage examples and documentation are provided in the respective `README.md` files. [[1]](diffhunk://#diff-6cbc86e3225fcd4831d822546917f658b67bc18c0c487e3b444d4ccf5c732525R59-R131) [[2]](diffhunk://#diff-c2cd4d98c0be637a585834ea907177e62082548e5368af2727637af9b68e94e1R75-R130) [[3]](diffhunk://#diff-1ecb319ee37f8e13a3f994d919f9efd34d3a6cd7cad269e5419bc2dbb51d1949L235-R298) [[4]](diffhunk://#diff-0b0eb79e73a3fb6ff8fb51fcfaa26ca0090131139b81f71a177ff107fe21ab06L298-R347)

### Documentation Improvements

* Expanded and clarified documentation in `README.md` for both Echo and Gin, including new sections and examples for registering handlers for all methods, wrapping standard handlers, and using middleware. [[1]](diffhunk://#diff-1ecb319ee37f8e13a3f994d919f9efd34d3a6cd7cad269e5419bc2dbb51d1949R82-R116) [[2]](diffhunk://#diff-1ecb319ee37f8e13a3f994d919f9efd34d3a6cd7cad269e5419bc2dbb51d1949R130) [[3]](diffhunk://#diff-1ecb319ee37f8e13a3f994d919f9efd34d3a6cd7cad269e5419bc2dbb51d1949L235-R298) [[4]](diffhunk://#diff-0b0eb79e73a3fb6ff8fb51fcfaa26ca0090131139b81f71a177ff107fe21ab06L82-R116) [[5]](diffhunk://#diff-0b0eb79e73a3fb6ff8fb51fcfaa26ca0090131139b81f71a177ff107fe21ab06L298-R347)

### Refactoring and Consistency Updates

* Refactored handler registration calls in test files (`http/client_test.go` and others) to consistently pass the HTTP method as the first parameter, improving code clarity and reducing ambiguity. [[1]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L31-R36) [[2]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L65-R71) [[3]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L101-R101) [[4]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L140-R140) [[5]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L174-R174) [[6]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L212-R212) [[7]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L244-R249) [[8]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L275-R280) [[9]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L304-R304) [[10]](diffhunk://#diff-0a04f5d21c1d2223648ce05c57de7f0e6b9be9be2da51184c5b441a3602845e6L349-R349) [[11]](diffhunk://#diff-94f8f56cfc1f3b14bccaa8e53a15df997e40f0c1c22a2e21e2ffa6fcba06411fL169-R169) [[12]](diffhunk://#diff-c95cbeb31c028532c9ad4bc51289e2d2b976398a76ef26ad1e730f8e8ced40b1L86-R86)

### Deprecated or Removed Features

* Removed the `RegisterHandlerMethods` function from Gin's documentation, streamlining the API to favor single-method or all-method handler registration for clarity and simplicity.

These changes make it easier to integrate standard Go HTTP handlers with Echo and Gin, provide more flexible handler registration, and improve documentation for developers using these frameworks.