### PR TITLE
[#179] Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/staticcheck
-          key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/*.go') }}
+          key: ${{ runner.os }}-staticcheck-${{ matrix.go }}-${{ hashFiles('**/*.go') }}
           restore-keys: |
+            ${{ runner.os }}-staticcheck-${{ matrix.go }}-
             ${{ runner.os }}-staticcheck-
 
       - name: Install Tools
@@ -220,7 +221,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.cache/staticcheck
-          key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/*.go') }}
+          key: ${{ runner.os }}-staticcheck-${{ matrix.go }}-${{ hashFiles('**/*.go') }}
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
This pull request makes a small but important update to the CI workflow cache keys in `.github/workflows/ci.yml`. The cache keys for `staticcheck` now include the Go version from the matrix, ensuring that caches are correctly separated for different Go versions.

- CI workflow improvements:
  * Updated `staticcheck` cache keys in both restore and save steps to include `${{ matrix.go }}`, preventing cache conflicts between different Go versions. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL63-R65) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL223-R224)